### PR TITLE
feat: MCP client の実装 (#99)

### DIFF
--- a/botcast-worker/Cargo.lock
+++ b/botcast-worker/Cargo.lock
@@ -95,12 +95,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,7 +343,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "http 1.1.0",
- "indexmap 2.5.0",
+ "indexmap 2.14.0",
  "mime",
  "multer",
  "num-traits",
@@ -398,7 +392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e3ef112905abea9dea592fc868a6873b10ebd3f983e83308f995d6284e9ba41"
 dependencies = [
  "bytes",
- "indexmap 2.5.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
 ]
@@ -490,9 +484,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1062,17 +1056,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1357,6 +1350,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +1388,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1418,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.89",
 ]
@@ -2074,7 +2101,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.5.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2148,6 +2175,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -2686,13 +2719,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2896,9 +2930,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -3260,6 +3294,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3699,6 +3745,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
 name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3764,7 +3816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4044,6 +4096,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap 2.14.0",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4060,7 +4126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.89",
@@ -4545,6 +4611,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "process-wrap",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4905,10 +5008,24 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -5139,10 +5256,11 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -5156,10 +5274,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.210"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5173,7 +5311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d2de91cf02bbc07cde38891769ccd5d4f073d22a40683aa4bc7a95781aaa2c4"
 dependencies = [
  "form_urlencoded",
- "indexmap 2.5.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -5185,7 +5323,7 @@ version = "1.0.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67d42a0bd4ac281beff598909bb56a86acaf979b84483e1c79c10dcaf98f8cf3"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "ryu",
@@ -5235,7 +5373,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.5.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde",
@@ -5522,7 +5660,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "hashlink",
  "hex",
- "indexmap 2.5.0",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "native-tls",
@@ -5852,7 +5990,7 @@ dependencies = [
  "dmp",
  "futures",
  "geo",
- "indexmap 2.5.0",
+ "indexmap 2.14.0",
  "path-clean",
  "pharos",
  "reblessive",
@@ -6036,7 +6174,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -6319,7 +6457,7 @@ version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.14.0",
  "toml_datetime",
  "winnow",
 ]
@@ -7005,6 +7143,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7019,10 +7178,34 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading",
 ]
 
 [[package]]
@@ -7037,10 +7220,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7060,13 +7265,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result 0.3.2",
- "windows-strings",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
@@ -7089,12 +7304,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link 0.1.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7178,6 +7411,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7354,6 +7596,7 @@ dependencies = [
  "readable_text",
  "repos",
  "reqwest",
+ "rmcp",
  "sea-orm",
  "serde",
  "serde_json",

--- a/botcast-worker/crates/worker/Cargo.toml
+++ b/botcast-worker/crates/worker/Cargo.toml
@@ -46,3 +46,4 @@ async-trait = "0.1.83"
 cron = "0.12.1"
 thiserror = "1.0.64"
 kafru = "1.0.4"
+rmcp = { version = "1.6.0", features = ["client", "transport-child-process"] }

--- a/botcast-worker/crates/worker/src/usecase/agent_service.rs
+++ b/botcast-worker/crates/worker/src/usecase/agent_service.rs
@@ -1,0 +1,161 @@
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use super::mcp_client::McpClient;
+
+const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const MAX_TOKENS: u32 = 8192;
+const MAX_ITERATIONS: usize = 20;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AnthropicTool {
+    name: String,
+    description: String,
+    input_schema: Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Message {
+    role: String,
+    content: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicResponse {
+    content: Vec<ContentBlock>,
+    stop_reason: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ContentBlock {
+    Text { text: String },
+    ToolUse { id: String, name: String, input: Value },
+}
+
+pub struct AgentService {
+    api_key: String,
+    model: String,
+    mcp_client: McpClient,
+    http_client: reqwest::Client,
+}
+
+impl AgentService {
+    pub fn new(api_key: String, mcp_client: McpClient) -> Self {
+        let model =
+            std::env::var("ANTHROPIC_MODEL").unwrap_or_else(|_| "claude-opus-4-7".to_string());
+        Self {
+            api_key,
+            model,
+            mcp_client,
+            http_client: reqwest::Client::new(),
+        }
+    }
+
+    fn tools_for_anthropic(&self) -> Vec<AnthropicTool> {
+        self.mcp_client
+            .tools()
+            .iter()
+            .map(|t| AnthropicTool {
+                name: t.name.to_string(),
+                description: t.description.as_deref().unwrap_or("").to_string(),
+                input_schema: Value::Object((*t.input_schema).clone()),
+            })
+            .collect()
+    }
+
+    pub async fn run(&self, system: &str, prompt: &str) -> anyhow::Result<String> {
+        let tools = self.tools_for_anthropic();
+        let mut messages: Vec<Message> = vec![Message {
+            role: "user".to_string(),
+            content: json!(prompt),
+        }];
+
+        for _ in 0..MAX_ITERATIONS {
+            let body = json!({
+                "model": self.model,
+                "max_tokens": MAX_TOKENS,
+                "system": system,
+                "tools": tools,
+                "messages": messages,
+            });
+
+            let response = self
+                .http_client
+                .post(ANTHROPIC_API_URL)
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", ANTHROPIC_VERSION)
+                .header("content-type", "application/json")
+                .json(&body)
+                .send()
+                .await
+                .context("Failed to call Anthropic API")?;
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                anyhow::bail!("Anthropic API error {}: {}", status, body);
+            }
+
+            let resp: AnthropicResponse =
+                response.json().await.context("Failed to parse Anthropic response")?;
+
+            let assistant_content: Value = serde_json::to_value(&resp.content)
+                .context("Failed to serialize assistant content")?;
+            messages.push(Message {
+                role: "assistant".to_string(),
+                content: assistant_content,
+            });
+
+            if resp.stop_reason == "end_turn" || resp.stop_reason == "stop_sequence" {
+                let text = resp
+                    .content
+                    .iter()
+                    .filter_map(|b| {
+                        if let ContentBlock::Text { text } = b {
+                            Some(text.as_str())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                return Ok(text);
+            }
+
+            if resp.stop_reason == "tool_use" {
+                let mut tool_results = Vec::new();
+                for block in &resp.content {
+                    if let ContentBlock::ToolUse { id, name, input } = block {
+                        tracing::info!("Agent calling tool: {} with {:?}", name, input);
+                        let result = self
+                            .mcp_client
+                            .call_tool(name.clone(), input.clone())
+                            .await
+                            .unwrap_or_else(|e| format!("Tool error: {}", e));
+                        tool_results.push(json!({
+                            "type": "tool_result",
+                            "tool_use_id": id,
+                            "content": result,
+                        }));
+                    }
+                }
+                messages.push(Message {
+                    role: "user".to_string(),
+                    content: json!(tool_results),
+                });
+                continue;
+            }
+
+            anyhow::bail!("Unexpected stop_reason: {}", resp.stop_reason);
+        }
+
+        anyhow::bail!("Agent exceeded max iterations ({})", MAX_ITERATIONS)
+    }
+
+    pub async fn close(self) -> anyhow::Result<()> {
+        self.mcp_client.close().await
+    }
+}

--- a/botcast-worker/crates/worker/src/usecase/mcp_client.rs
+++ b/botcast-worker/crates/worker/src/usecase/mcp_client.rs
@@ -1,0 +1,95 @@
+use anyhow::Context;
+use rmcp::{
+    ServiceExt,
+    model::{CallToolRequestParams, Tool},
+    service::RunningService,
+    transport::{ConfigureCommandExt, TokioChildProcess},
+};
+use serde_json::Value;
+use tokio::process::Command;
+
+pub struct McpClient {
+    service: RunningService<rmcp::RoleClient, ()>,
+    tools: Vec<Tool>,
+}
+
+impl McpClient {
+    pub async fn new(mcp_cmd: &str, mcp_args: &[&str]) -> anyhow::Result<Self> {
+        let transport = TokioChildProcess::new(Command::new(mcp_cmd).configure(|cmd| {
+            cmd.args(mcp_args);
+        }))
+        .context("Failed to spawn MCP server process")?;
+
+        let service = ().serve(transport).await.context("Failed to connect to MCP server")?;
+        let tools = service.list_all_tools().await.context("Failed to list MCP tools")?;
+
+        Ok(Self { service, tools })
+    }
+
+    pub fn tools(&self) -> &[Tool] {
+        &self.tools
+    }
+
+    pub async fn call_tool(
+        &self,
+        name: impl Into<std::borrow::Cow<'static, str>>,
+        arguments: Value,
+    ) -> anyhow::Result<String> {
+        let arguments = arguments
+            .as_object()
+            .cloned()
+            .unwrap_or_default();
+
+        let result = self
+            .service
+            .call_tool(CallToolRequestParams::new(name).with_arguments(arguments))
+            .await
+            .context("Failed to call MCP tool")?;
+
+        let text = result
+            .content
+            .iter()
+            .filter_map(|c| {
+                if let rmcp::model::RawContent::Text(t) = &c.raw {
+                    Some(t.text.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Ok(text)
+    }
+
+    pub async fn close(self) -> anyhow::Result<()> {
+        self.service.cancel().await.context("Failed to close MCP client")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mcp_server_path() -> String {
+        std::env::var("MCP_SERVER_ARGS")
+            .unwrap_or_else(|_| "/Users/kmt/dev/botcast-cms/mcp/build/index.js".to_string())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires botcast-cms MCP server to be built"]
+    async fn mcp_client_lists_tools() {
+        let path = mcp_server_path();
+        let args: Vec<&str> = path.split_whitespace().collect();
+        let client = McpClient::new("node", &args).await.expect("failed to create client");
+        let tools = client.tools();
+        assert!(!tools.is_empty(), "expected at least one tool");
+        let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(
+            tool_names.contains(&"RecordApi_list"),
+            "expected RecordApi_list tool"
+        );
+        client.close().await.unwrap();
+    }
+}

--- a/botcast-worker/crates/worker/src/usecase/mcp_client.rs
+++ b/botcast-worker/crates/worker/src/usecase/mcp_client.rs
@@ -92,4 +92,22 @@ mod tests {
         );
         client.close().await.unwrap();
     }
+
+    #[tokio::test]
+    #[ignore = "requires botcast-cms MCP server to be built"]
+    async fn mcp_client_calls_record_list() {
+        let path = mcp_server_path();
+        let args: Vec<&str> = path.split_whitespace().collect();
+        let client = McpClient::new("node", &args).await.expect("failed to create client");
+        let tool_names: Vec<&str> = client.tools().iter().map(|t| t.name.as_ref()).collect();
+        eprintln!("available tools: {:?}", tool_names);
+        let result = client
+            .call_tool("RecordApi_list", serde_json::json!({ "collectionId": "episodes" }))
+            .await
+            .expect("failed to call tool");
+        assert!(!result.is_empty(), "expected non-empty result");
+        eprintln!("result: {}", result);
+        assert!(result.contains("Status:"), "expected API response in: {}", result);
+        client.close().await.unwrap();
+    }
 }

--- a/botcast-worker/crates/worker/src/usecase/mod.rs
+++ b/botcast-worker/crates/worker/src/usecase/mod.rs
@@ -1,4 +1,6 @@
+pub(crate) mod agent_service;
 pub(crate) mod episode_service;
+pub(crate) mod mcp_client;
 pub(crate) mod provider;
 pub(crate) mod task_service;
 

--- a/botcast-worker/crates/worker/src/usecase/task_service.rs
+++ b/botcast-worker/crates/worker/src/usecase/task_service.rs
@@ -1,4 +1,6 @@
+use super::agent_service::AgentService;
 use super::episode_service::EpisodeService;
+use super::mcp_client::McpClient;
 use crate::error::Error;
 use crate::worker::use_work_dir;
 use anyhow::Context;
@@ -22,6 +24,10 @@ use uuid::Uuid;
 pub(crate) enum Args {
     GenerateAudio {
         episode_id: EpisodeId,
+    },
+    GenerateScript {
+        episode_id: EpisodeId,
+        prompt: String,
     },
 }
 
@@ -99,6 +105,10 @@ impl TaskService {
                     .await?;
                 Ok(serde_json::Value::String("OK".to_string()))
             }
+            Args::GenerateScript { episode_id, prompt } => {
+                let result = self.run_generate_script(&episode_id, &prompt).await?;
+                Ok(serde_json::Value::String(result))
+            }
         }
     }
 
@@ -147,9 +157,90 @@ impl TaskService {
         Ok(())
     }
 
+    async fn run_generate_script(
+        &self,
+        episode_id: &EpisodeId,
+        prompt: &str,
+    ) -> anyhow::Result<String, Error> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY")
+            .context("ANTHROPIC_API_KEY is not set")
+            .map_err(Error::Other)?;
+        let mcp_cmd = std::env::var("MCP_SERVER_CMD").unwrap_or_else(|_| "node".to_string());
+        let mcp_args_str = std::env::var("MCP_SERVER_ARGS")
+            .unwrap_or_else(|_| "/Users/kmt/dev/botcast-cms/mcp/build/index.js".to_string());
+        let mcp_args: Vec<&str> = mcp_args_str.split_whitespace().collect();
+
+        let mcp_client = McpClient::new(&mcp_cmd, &mcp_args)
+            .await
+            .context("Failed to create MCP client")
+            .map_err(Error::Other)?;
+
+        let agent = AgentService::new(api_key, mcp_client);
+
+        let system = "あなたはポッドキャストの台本を生成するアシスタントです。\
+MCPツールを使用してエピソードの台本を生成し、CMSに保存してください。\
+台本はsectionsフィールドに格納され、各セクションはSerifSection(speaker, text)またはAudioSection(url, from, to)の形式です。";
+
+        let full_prompt = format!(
+            "エピソードID: {}\n\n{}",
+            episode_id.0.hyphenated(),
+            prompt
+        );
+
+        let result = agent
+            .run(system, &full_prompt)
+            .await
+            .context("Agent failed")
+            .map_err(Error::Other)?;
+
+        agent.close().await.map_err(Error::Other)?;
+
+        Ok(result)
+    }
+
     pub(crate) async fn execute_by_id(&self, task_id: &TaskId) -> anyhow::Result<(), Error> {
         let task = self.task_repo.find_by_id(task_id).await?;
         tracing::info!("Executing task: {} args={}", task.id, task.args);
         self.run_task(task).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repos::id::EpisodeId;
+    use uuid::Uuid;
+
+    #[test]
+    fn args_generate_audio_serializes_correctly() {
+        let episode_id = EpisodeId(Uuid::nil());
+        let args = Args::GenerateAudio { episode_id };
+        let json = serde_json::to_value(&args).unwrap();
+        assert_eq!(json["type"], "generateAudio");
+        assert!(json["episodeId"].is_string());
+    }
+
+    #[test]
+    fn args_generate_script_serializes_correctly() {
+        let episode_id = EpisodeId(Uuid::nil());
+        let args = Args::GenerateScript {
+            episode_id,
+            prompt: "テスト台本を生成してください".to_string(),
+        };
+        let json = serde_json::to_value(&args).unwrap();
+        assert_eq!(json["type"], "generateScript");
+        assert_eq!(json["prompt"], "テスト台本を生成してください");
+        assert!(json["episodeId"].is_string());
+    }
+
+    #[test]
+    fn args_deserializes_generate_script() {
+        let json = serde_json::json!({
+            "type": "generateScript",
+            "episodeId": Uuid::nil().to_string(),
+            "prompt": "プロンプト"
+        });
+        let args: Args = serde_json::from_value(json).unwrap();
+        assert!(matches!(args, Args::GenerateScript { .. }));
     }
 }


### PR DESCRIPTION
## Summary

Issue #99 の実装。botcast-cms の MCP サーバー（stdio トランスポート）に接続する MCP クライアントと、それを使った LLM エージェントを実装する。

## Changes

- `mcp_client.rs`: rmcp クレートを使って botcast-cms MCP サーバーをサブプロセスとして起動し、stdio 経由で接続する `McpClient` を実装
- `agent_service.rs`: Anthropic API (Claude) + MCP ツールコールを使った `AgentService` を実装（`tool_use` → MCP 呼び出し → `tool_result` のループ）
- `task_service.rs`: `Args::GenerateScript { episode_id, prompt }` タスクを追加し、エージェントで台本生成を行う `run_generate_script` メソッドを実装
- `Cargo.toml`: `rmcp` (v1.6.0, client + transport-child-process feature) を追加

## Testing

- [x] `Args` の serialize/deserialize ユニットテスト (3件) パス
- [x] `cargo check` / `just check` でワークスペース全体ビルド確認
- [x] MCP サーバー接続の結合テストを `#[ignore]` 付きで追加（`botcast-cms` ビルド環境で手動実行可能）

resolve #99