### PR TITLE
feat: MCP 経由での CMS コレクション初期化・podcast/episode テスト追加

### DIFF
--- a/botcast-worker/crates/worker/src/main.rs
+++ b/botcast-worker/crates/worker/src/main.rs
@@ -9,6 +9,50 @@ use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::EnvFilter;
 use worker::{api::start_api, usecase::Provider, worker::start_worker};
+use worker::usecase::mcp_client::McpClient;
+
+async fn seed_cms_collections() -> anyhow::Result<()> {
+    let mcp_cmd = std::env::var("MCP_SERVER_CMD").unwrap_or_else(|_| "node".to_string());
+    let mcp_args_str = match std::env::var("MCP_SERVER_ARGS") {
+        Ok(v) => v,
+        Err(_) => {
+            tracing::warn!("MCP_SERVER_ARGS not set, skipping CMS collection seeding");
+            return Ok(());
+        }
+    };
+    let mcp_args: Vec<&str> = mcp_args_str.split_whitespace().collect();
+    let client = McpClient::new(&mcp_cmd, &mcp_args).await?;
+
+    let podcasts_schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "title": { "type": "string" },
+            "icon": { "type": "string" },
+            "description": { "type": "string" },
+            "user_id": { "type": "string" }
+        },
+        "required": ["title", "icon", "user_id"]
+    });
+    let episodes_schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "title": { "type": "string" },
+            "podcast_id": { "type": "string" },
+            "description": { "type": "string" },
+            "audio_url": { "type": "string" },
+            "srt_url": { "type": "string" },
+            "sections": { "type": "array" },
+            "duration_sec": { "type": "integer" },
+            "user_id": { "type": "string" }
+        },
+        "required": ["title", "podcast_id", "user_id"]
+    });
+
+    client.ensure_collection("podcasts", podcasts_schema).await?;
+    client.ensure_collection("episodes", episodes_schema).await?;
+    client.close().await?;
+    Ok(())
+}
 
 fn init_tracing(otlp_collector_endpoint: String) -> anyhow::Result<()> {
     let crate_name = env!("CARGO_CRATE_NAME");
@@ -49,6 +93,8 @@ async fn main() -> anyhow::Result<()> {
             .map_err(|e| anyhow::anyhow!("Failed to connect to kafru DB: {}", e))?,
     );
     let kafru_queue = Arc::new(kafru::queue::Queue::new(Some(kafru_db.clone())).await);
+
+    seed_cms_collections().await?;
 
     let provider = Arc::new(Provider::new(kafru_queue));
     start_worker(provider.clone(), kafru_db);

--- a/botcast-worker/crates/worker/src/usecase/mcp_client.rs
+++ b/botcast-worker/crates/worker/src/usecase/mcp_client.rs
@@ -62,6 +62,32 @@ impl McpClient {
         Ok(text)
     }
 
+    /// コレクションが存在しなければ作成する（冪等）。
+    pub async fn ensure_collection(
+        &self,
+        name: &str,
+        schema: serde_json::Value,
+    ) -> anyhow::Result<()> {
+        let list = self.call_tool("CollectionApi_list", serde_json::json!({})).await?;
+        let start = list.find('[').or_else(|| list.find('{')).context("no JSON in CollectionApi_list response")?;
+        let collections: serde_json::Value = serde_json::from_str(&list[start..])?;
+        let exists = collections
+            .as_array()
+            .map(|arr| arr.iter().any(|c| c["name"] == name))
+            .unwrap_or(false);
+        if exists {
+            tracing::info!("collection '{}' already exists, skipping", name);
+            return Ok(());
+        }
+        self.call_tool(
+            "CollectionApi_create",
+            serde_json::json!({ "requestBody": { "name": name, "schema": schema } }),
+        )
+        .await?;
+        tracing::info!("created collection '{}'", name);
+        Ok(())
+    }
+
     pub async fn close(self) -> anyhow::Result<()> {
         self.service.cancel().await.context("Failed to close MCP client")?;
         Ok(())
@@ -74,6 +100,35 @@ mod tests {
 
     fn mcp_server_path() -> String {
         std::env::var("MCP_SERVER_ARGS").expect("MCP_SERVER_ARGS is not set")
+    }
+
+    async fn make_client() -> McpClient {
+        let path = mcp_server_path();
+        let args: Vec<&str> = path.split_whitespace().collect();
+        McpClient::new("node", &args).await.expect("failed to create client")
+    }
+
+    async fn resolve_collection_id(client: &McpClient, name: &str) -> String {
+        let raw = client
+            .call_tool("CollectionApi_list", serde_json::json!({}))
+            .await
+            .expect("failed to list collections");
+        let start = raw.find('[').or_else(|| raw.find('{')).expect("no JSON in response");
+        let json: serde_json::Value = serde_json::from_str(&raw[start..]).expect("invalid JSON");
+        json.as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["name"] == name)
+            .and_then(|c| c["id"].as_str())
+            .and_then(|id| id.strip_prefix("collection:"))
+            .unwrap_or_else(|| panic!("collection '{}' not found", name))
+            .to_string()
+    }
+
+    fn parse_created_id(result: &str) -> String {
+        let start = result.find('{').expect("no JSON in result");
+        let json: serde_json::Value = serde_json::from_str(&result[start..]).expect("invalid JSON");
+        json["id"].as_str().expect("id field missing").to_string()
     }
 
     #[tokio::test]
@@ -89,6 +144,72 @@ mod tests {
             tool_names.contains(&"RecordApi_list"),
             "expected RecordApi_list tool"
         );
+        client.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore = "requires botcast-cms MCP server to be built"]
+    async fn mcp_client_creates_podcast() {
+        let client = make_client().await;
+        let col_id = resolve_collection_id(&client, "podcasts").await;
+
+        let result = client
+            .call_tool(
+                "RecordApi_create",
+                serde_json::json!({
+                    "collectionId": col_id,
+                    "requestBody": { "data": { "title": "test podcast", "icon": "🎙️", "user_id": "test-user" } }
+                }),
+            )
+            .await
+            .expect("failed to call tool");
+        eprintln!("result: {}", result);
+        assert!(result.contains("201"), "expected 201: {}", result);
+        client.close().await.unwrap();
+    }
+
+
+    #[tokio::test]
+    #[ignore = "requires botcast-cms MCP server to be built"]
+    async fn mcp_client_creates_episode() {
+        let client = make_client().await;
+
+        // まず podcast を作成して podcast_id を取得
+        let podcast_col_id = resolve_collection_id(&client, "podcasts").await;
+        let podcast_result = client
+            .call_tool(
+                "RecordApi_create",
+                serde_json::json!({
+                    "collectionId": podcast_col_id,
+                    "requestBody": { "data": { "title": "podcast for episode test", "icon": "🎙️", "user_id": "test-user" } }
+                }),
+            )
+            .await
+            .expect("failed to create podcast");
+        assert!(podcast_result.contains("201"), "podcast creation failed: {}", podcast_result);
+        let podcast_record_id = parse_created_id(&podcast_result);
+        eprintln!("created podcast id: {}", podcast_record_id);
+
+        // episode を作成
+        let ep_col_id = resolve_collection_id(&client, "episodes").await;
+        let result = client
+            .call_tool(
+                "RecordApi_create",
+                serde_json::json!({
+                    "collectionId": ep_col_id,
+                    "requestBody": {
+                        "data": {
+                            "title": "test episode",
+                            "podcast_id": podcast_record_id,
+                            "user_id": "test-user"
+                        }
+                    }
+                }),
+            )
+            .await
+            .expect("failed to call tool");
+        eprintln!("result: {}", result);
+        assert!(result.contains("201"), "expected 201: {}", result);
         client.close().await.unwrap();
     }
 

--- a/botcast-worker/crates/worker/src/usecase/mod.rs
+++ b/botcast-worker/crates/worker/src/usecase/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod agent_service;
 pub(crate) mod episode_service;
-pub(crate) mod mcp_client;
+pub mod mcp_client;
 pub(crate) mod provider;
 pub(crate) mod task_service;
 


### PR DESCRIPTION
## Summary

- `McpClient::ensure_collection` を追加（コレクションが存在しなければ MCP 経由で作成・冪等）
- botcast 起動時に `seed_cms_collections` で `podcasts` / `episodes` コレクションを初期化
  - botcast-cms 側の `seed_collections` 廃止（#42）に対応
  - `MCP_SERVER_ARGS` 未設定時はスキップ
- `mcp_client_creates_podcast` / `mcp_client_creates_episode` テストを追加
- テストヘルパー `make_client` / `resolve_collection_id` / `parse_created_id` を追加して重複を削減
- `usecase::mcp_client` を `pub` に変更（バイナリの `main.rs` からアクセスするため）

## Test plan

- [ ] `cargo test --package worker mcp_client_creates -- --nocapture --ignored` が全て通ること（要 botcast-cms MCP サーバー起動）
- [ ] botcast-cms の `seed_collections` なしで起動し、podcasts/episodes コレクションが作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)